### PR TITLE
Issue135

### DIFF
--- a/modules/calendar/calendar.class.php
+++ b/modules/calendar/calendar.class.php
@@ -361,18 +361,18 @@ class CMonthCalendar {
 					$html .= ' style="border: 1px solid ' . $this->highlightedDays[$day] . '"';
 				}
 				$html .= ' onclick="' . $this->dayFunc . '(\'' . $day . '\',\'' . $this_day->format($df) . '\')' . '">';
-				if ($m == $this_month) {
-					if ($this->dayFunc) {
-						$html .= "<a href=\"javascript:$this->dayFunc('$day','" . $this_day->format($df) . "')\" class=\"$class\">";
-						$html .= $d;
-						$html .= '</a>';
-					} else {
-						$html .= $d;
-					}
-					if ($this->showEvents) {
-						$html .= $this->_drawEvents(substr($day, 0, 8));
-					}
-				}
+
+                                if ($this->dayFunc) {
+                                        $html .= "<a href=\"javascript:$this->dayFunc('$day','" . $this_day->format($df) . "')\" class=\"$class\">";
+                                        $html .= $d;
+                                        $html .= '</a>';
+                                } else {
+                                        $html .= $d;
+                                }
+                                if ($this->showEvents) {
+                                        $html .= $this->_drawEvents(substr($day, 0, 8));
+                                }
+                                
 				$html .= '</td>';
 			}
 			$html .= '</tr>';

--- a/modules/calendar/index.php
+++ b/modules/calendar/index.php
@@ -62,12 +62,44 @@ function clickWeek( uts, fdate ) {
 $date = new CDate($date);
 
 // prepare time period for 'events'
+// "go back" to the first day shown on the calendar
+// and "go forward" to the last day shown on the calendar
 $first_time = new CDate($date);
 $first_time->setDay(1);
 $first_time->setTime(0, 0, 0);
+
+// if Sunday is the 1st, we don't need to go back
+// as that's the first day shown on the calendar
+if($first_time->getDayOfWeek() != 0) {
+    $last_day_of_previous_month = $first_time->getPrevDay();
+    $day_of_previous_month = $last_day_of_previous_month->getDayOfWeek();
+    $seconds_to_sub_in_previous_month = 86400 * $day_of_previous_month;
+    // need to cast it to int because Pear::Date_Span::set down the line
+    // fails to set the seconds correctly
+    $last_day_of_previous_month->subtractSeconds((int)$seconds_to_sub_in_previous_month);
+
+    $first_time->setDay($last_day_of_previous_month->getDay());
+    $first_time->setMonth($last_day_of_previous_month->getMonth());
+    $first_time->setYear($last_day_of_previous_month->getYear());
+}
+
 $last_time = new CDate($date);
 $last_time->setDay($date->getDaysInMonth());
 $last_time->setTime(23, 59, 59);
+
+// if Saturday is the last day of month, we don't need to go forward
+// as that's the last day shown on the calendar
+if($last_time->getDayOfWeek() != 6) {
+    $first_day_of_next_month = $last_time->getNextDay();
+    $day_of_next_month = $first_day_of_next_month->getDayOfWeek();
+    $seconds_to_add_in_next_month = 86400 * $day_of_next_month;
+    // need to cast it to int because Pear::Date_Span::set down the line
+    // fails to set the seconds correctly
+    $first_day_of_next_month->addSeconds((int)$seconds_to_add_in_next_month);
+    $last_time->setDay($first_day_of_next_month->getDay());
+    $last_time->setMonth($first_day_of_next_month->getMonth());
+    $last_time->setYear($first_day_of_next_month->getYear());
+}
 
 $links = array();
 

--- a/style/w2p-snowball/main.css
+++ b/style/w2p-snowball/main.css
@@ -574,6 +574,7 @@ table.minical td.week {
 }
 table.minical td.empty {
 	color: #aaaaaa;
+        background-color: #E0E0E0;
 }
 table.minical td.day  {
 	text-align : center;

--- a/style/web2project/main.css
+++ b/style/web2project/main.css
@@ -493,6 +493,7 @@ table.minical td.week {
 }
 table.minical td.empty {
   color: #aaaaaa;
+  background-color: #E0E0E0;
 }
 table.minical td.day  {
   text-align: center;

--- a/style/wps-redmond/main.css
+++ b/style/wps-redmond/main.css
@@ -535,6 +535,7 @@ table.minical td.week {
 }
 table.minical td.empty {
 	color: #aaaaaa;
+        background-color: #E0E0E0;
 }
 table.minical td.day  {
 	text-align : center;


### PR DESCRIPTION
Hi Keith!

It's me again :D

This is a pull request for issue 135 http://bugs.web2project.net/view.php?id=135 Simple "look ahead" for coming month.

When viewing the calendar in month view the starting date is not the 1st of the month, but the first day shown on the calendar. Also, same applies for the finish date - the finish date is now the last day shown.

All the calculations are done via the existing Date classes.

I've edited the styles a bit too, on the minicalendars a background color was missing for the .empty CSS class.

Cheers!
