### PR TITLE
new task project was overriding task project

### DIFF
--- a/modules/tasks/do_task_aed.php
+++ b/modules/tasks/do_task_aed.php
@@ -47,7 +47,7 @@ if (!$obj->bind($_POST)) {
 }
 
 // Check to see if the task_project has changed
-if ($obj->task_project != $new_task_project) {
+if ($new_task_project != 0 and $obj->task_project != $new_task_project) {
     $taskRecount = ($obj->task_project) ? $obj->task_project : 0;
     $obj->task_project = $new_task_project;
     $obj->task_parent = $obj->task_id;


### PR DESCRIPTION
Hi Keith!

This is a quick fix for http://bugs.web2project.net/view.php?id=808

If $new_task_project wasn't set, it would be always 0 and always different from $obj->task_project thus always overriding $obj->task_project with 0.

Have fun at #tek11 ;)
