### PR TITLE
dont strip newlines from textareas in ff and ie

### DIFF
--- a/modules/tasks/addedit.js
+++ b/modules/tasks/addedit.js
@@ -69,7 +69,7 @@ function submitIt(form){
 			form.task_name.focus();
 			return false;
 	}
-
+        
 	// Check the sub forms
 	for (var i = 0, i_cmp = subForm.length; i < i_cmp; i++) {
 		if (!subForm[i].check())
@@ -78,7 +78,6 @@ function submitIt(form){
 		// with data
 		subForm[i].save();
 	}
-
 	form.submit();
 }
 
@@ -627,10 +626,14 @@ function copyForm(form, to, extras) {
 		// Determine the node type, and determine the current value
 		switch (elem.type) {
 			case 'text':
-			case 'textarea':
 			case 'hidden':
-				to.appendChild(h.addHidden(elem.name, elem.value));
+				to.appendChild(h.addHidden(elem.name, elem.value, elem.type));
 				break;
+                        case 'textarea':
+                                to.appendChild(h.addHidden(elem.name, elem.value, elem.type));
+                                var newHidden = document.getElementById(elem.name);
+                                newHidden.value = elem.value;
+                                break;
 			case 'select-one':
 				if (elem.options.length > 0) {
 					to.appendChild(h.addHidden(elem.name, elem.options[elem.selectedIndex].value));


### PR DESCRIPTION
Hello :)

This is a fix for the stripped new lines in the task descriptions. Was happening only in IE and FF, Chrome was OK.

The problem was that deep in js/base.js, while copying an element from a textarea to a hidden field, the value from the textarea was added to value attribute in the hidden field, and not to it's .value... errmm.. attribute. Ugh, I confused even myself.

In code, elem.setAttribute('value', my_value) is used, but elem.value = my_value should be used. This fix does exactly that. Will need to dig deeper and see if any other parts of w2p are affected with this, if yes, then js/base.js will need to be changed. More on this madness: http://www.quirksmode.org/dom/w3c_core.html#attributes
