### PR TITLE
Fix for 'Actions' section in ProjectDesigner

### DIFF
--- a/modules/projectdesigner/vw_actions.php
+++ b/modules/projectdesigner/vw_actions.php
@@ -72,7 +72,7 @@ $q->clear();
 foreach ($root_tasks as $root_task) {
 	build_date_list($projTasksWithEndDates, $root_task);
 	if ($root_task['task_id'] != $task_id) {
-		constructTaskTree($root_task, $parents, $all_tasks);
+		constructTaskTree($root_task);
 	}
 }
 
@@ -216,44 +216,3 @@ $spercent = arrayMerge(array('' => '('.$AppUI->_('Progress').')'), $percent);
         </tr>
     </table>
 </form>
-
-<?php
-function getSpaces($amount) {
-	if ($amount == 0) {
-		return '';
-	}
-	return str_repeat('&nbsp;', $amount);
-}
-
-function constructTaskTree($task_data, $parents, $all_tasks, $depth = 0) {
-	global $projTasks, $all_tasks, $task_parent_options, $task_parent, $task_id;
-
-	$projTasks[$task_data['task_id']] = $task_data['task_name'];
-	$task_data['task_name'] = mb_strlen($task_data[1]) > 45 ? mb_substr($task_data['task_name'], 0, 45) . "..." : $task_data['task_name'];
-	$task_parent_options .= '<option value="' . $task_data['task_id'] . '" >' . getSpaces($depth * 3) . w2PFormSafe($task_data['task_name']) . '</option>';
-
-	if (isset($parents[$task_data['task_id']])) {
-		foreach ($parents[$task_data['task_id']] as $child_task) {
-			if ($child_task != $task_id)
-				constructTaskTree($all_tasks[$child_task], $parents, $all_tasks, ($depth + 1));
-		}
-	}
-}
-
-function build_date_list(&$date_array, $row) {
-    global $project;
-
-	// if this task_dynamic is not tracked, set end date to proj start date
-	if (!in_array($row['task_dynamic'], CTask::$tracked_dynamics)) {
-		$date = new w2p_Utilities_Date($project->project_start_date);
-	} elseif ($row['task_milestone'] == 0) {
-		$date = new w2p_Utilities_Date($row['task_end_date']);
-	} else {
-		$date = new w2p_Utilities_Date($row['task_start_date']);
-	}
-	$sdate = $date->format('%d/%m/%Y');
-	$shour = $date->format('%H');
-	$smin = $date->format('%M');
-
-	$date_array[$row['task_id']] = array($row['task_name'], $sdate, $shour, $smin);
-}


### PR DESCRIPTION
Removed duplicated functions (and calls fixed) already present in cleanup_functions.php from vw_actions.php (Project Designer module)

It made the Project Designer module not to show correctly (empty Actions section).
