### PR TITLE
add fields: event_created, updated, creator, updator to db, corresponding to projects, tasks tables

### DIFF
--- a/install/sql/mysql/addEventCreatedUpdated.sql
+++ b/install/sql/mysql/addEventCreatedUpdated.sql
@@ -6,10 +6,12 @@
 
 --   The event_updator is added here for consistency with projects and tasks, 
 --   on the other hand, currently it is not updated in  those tables (12-04-05, opto) upon store
+
+--   Set created, updated default to 1999-12-31 in order not to break any ical feeds with invalid dates
 ALTER TABLE `events` ADD  `event_creator` int(10) NOT NULL DEFAULT '0';
 
 ALTER TABLE `events` ADD  `event_updator` int(10) NOT NULL DEFAULT '0';
 
-ALTER TABLE `events` ADD `event_created` DATETIME NOT NULL default '0000-00-00 00:00:00';
+ALTER TABLE `events` ADD `event_created` DATETIME NOT NULL default '1999-12-31 00:00:00';
 
-ALTER TABLE `events` ADD `event_updated` DATETIME NOT NULL default '0000-00-00 00:00:00';
+ALTER TABLE `events` ADD `event_updated` DATETIME NOT NULL default '1999-12-31 00:00:00';

--- a/modules/calendar/calendar.class.php
+++ b/modules/calendar/calendar.class.php
@@ -633,7 +633,7 @@ class CEvent extends w2p_Core_BaseObject
         $q->addQuery('event_description as description');
         $q->addQuery('event_start_date as startDate');
         $q->addQuery('event_end_date as endDate');
-        $q->addQuery("'" . $q->dbfnNowWithTZ() . "' as updatedDate");
+        $q->addQuery('event_updated  as updatedDate');
         $q->addQuery('CONCAT(\'' . W2P_BASE_URL . '/index.php?m=calendar&a=view&event_id=' . '\', e.event_id) as url');
         $q->addQuery('projects.project_id, projects.project_name');
         $q->addTable('events', 'e');


### PR DESCRIPTION
add fields: event_created, updated, creator, updator to db events table
adapt CEvent->store() to fill the new fields

sql: create fields, set default for dates to 1999 to prevent any strange icalfeed client reactions to date 0000

icalfeed: replace updateddate = dbfnnow for events with event_updated

event_updator added for consistency with tasks, projects. This field is currently not used for projects or tasks (project_updator stays always 0, for example, BUG???).

All changes needed for consistent ical sync of events (need real last updatedtime, not 'now' for that).
