### PR TITLE
Fix for #1083

### DIFF
--- a/install/sql/mysql/042_ResourceJoinFix.sql
+++ b/install/sql/mysql/042_ResourceJoinFix.sql
@@ -1,0 +1,4 @@
+-- Added by Korkonius
+-- Short fix to enable the other_resources view to function with all resources
+INSERT INTO `resource_types`(`resource_type_id`,`resource_type_name`,`resource_type_note`) VALUES(0, 'All resources', 'All resources');
+UPDATE `resource_types` SET `resource_type_id` = 0 WHERE `resource_type_id` = LAST_INSERT_ID();

--- a/modules/tasks/do_task_aed.php
+++ b/modules/tasks/do_task_aed.php
@@ -198,8 +198,16 @@ if ($result) {
         }
         $obj->pushDependencies($obj->task_id, $obj->task_end_date);
     }
-    // If there is a set of post_save functions, then we process them
+    // TODO: This is a hotfix for 1083, tasks_dosql.addedit.php is no longer run which is the root of the problem
+    // as no pre or post_save function is defined anymore (i could not find the core reason for this so ergo hotfix
+    if($AppUI->isActiveModule('resources')) {
+        global $other_resources;
+        $other_resources = w2PgetParam($_POST, 'hresource_assign');
 
+        resource_postsave();
+    }
+
+    // If there is a set of post_save functions, then we process them
     if (isset($post_save)) {
         foreach ($post_save as $post_save_function) {
             $post_save_function();


### PR DESCRIPTION
Hi!
This is a hotfix for bug #1083 which calls the resources_postsave() function and sets up required globals directly if the resources module is active. The hook functions was uninitialized in the previous version and i was unable to find the root for that.

Best Regards,
Eirik
