### PR TITLE
Fix http://bugs.web2project.net/view.php?id=1168

### DIFF
--- a/modules/system/index.php
+++ b/modules/system/index.php
@@ -81,6 +81,8 @@ $titleBlock->show();
         </div>
     </div>
 
+    <div class="clear"/>
+
     <div class="left main">
         <div class="left icon">
             <?php echo w2PshowImage('power-management.png', 42, 42, ''); ?>
@@ -99,6 +101,8 @@ $titleBlock->show();
             <a href="?m=system&a=translate"><?php echo $AppUI->_('Translation Management'); ?></a>
         </div>
     </div>
+
+    <div class="clear"/>
 
     <div class="left main">
         <div class="left icon">

--- a/style/common.css
+++ b/style/common.css
@@ -18,7 +18,7 @@ div {
     font-size:  8pt;
 }
 
-div.std { 
+div.std {
 	background: #fafafa;
     height:     1%;
     overflow:   hidden;
@@ -107,6 +107,10 @@ table.list tr:hover td {
 }
 table.list tr:hover td._name {
     font-weight: bold;
+}
+
+div.clear {
+    clear: both;
 }
 
 /*


### PR DESCRIPTION
Adds a div with clear: both, between each row to the System Administration screen so that when it gets small (<800px-ish) and the w2p admin email message is shown things don't blow up.
