### PR TITLE
Fix http://bugs.web2project.net/view.php?id=1174.

### DIFF
--- a/modules/contacts/addedit.php
+++ b/modules/contacts/addedit.php
@@ -10,9 +10,8 @@ $dept_id = (int) w2PgetParam($_GET, 'dept_id', 0);
 
 $row = new CContact();
 $row->contact_id = $contact_id;
-//TODO: CContact->canCreate() needs tweaking
-$row->contact_email = 'placeholder to pass canCreate()';
 
+//TODO: CContact->canCreate() needs tweaking
 $canAuthor = $row->canCreate();
 if (!$canAuthor && !$contact_id) {
     $AppUI->redirect('m=public&a=access_denied');
@@ -181,7 +180,7 @@ function companyChange() {
 	var f = document.changecontact;
 	if ( f.contact_company.value != window.company_value ){
 		f.contact_department.value = '';
-	} 
+	}
 }
 
 function updateVerify() {
@@ -208,7 +207,7 @@ function addContactMethod(field, value) {
 
     /* Create select menu for contact method type */
     function addOption(select, value, text, selected) {
-        var option = document.createElement('option'); 
+        var option = document.createElement('option');
         option.setAttribute("value", value);
         option.innerHTML = text;
         option.selected = (value == selected);
@@ -223,10 +222,10 @@ function addContactMethod(field, value) {
     /* Add text field for the contact method value to the table row */
     $('#contact_methods_' + index + '_').append('<td><input type="text" name="contact_methods[value][' + index + ']" size="25" maxlength="255" class="text" value="' + (value ? value : "") + '" /><?php echo w2PtoolTip('Contact Method', 'Remove') ?><a id="remove_contact_method" href="javascript:removeContactMethod(\'' + index + '\')"><img src="<?php echo w2PfindImage('icons/remove.png'); ?>" style="border: 0;" alt="" /></a><?php echo w2PendTip() ?></td>');
     addOption('#method_select_' + index, "", "");
-    <?php foreach ($methodLabels as $value => $text): ?> 
+    <?php foreach ($methodLabels as $value => $text): ?>
     addOption('#method_select_' + index, "<?php echo $value; ?>", "<?php echo $text; ?>", field);
     <?php endforeach; ?>
-    /* Make sure the newly added remove span has its tooltip working*/ 
+    /* Make sure the newly added remove span has its tooltip working*/
     $("span").tipTip({maxWidth: "auto", delay: 200, fadeIn: 150, fadeOut: 150});
 }
 

--- a/modules/contacts/contacts.class.php
+++ b/modules/contacts/contacts.class.php
@@ -187,7 +187,7 @@ class CContact extends w2p_Core_BaseObject
         if(mb_strlen($this->contact_first_name) <= 1) {
             $this->_error['contact_first_name'] = $baseErrorMsg . 'contact first name is not set';
         }
-        
+
         if(mb_strlen($this->contact_display_name) <= 1) {
             $this->_error['contact_display_name'] = $baseErrorMsg . 'contact display name is not set';
         }
@@ -201,7 +201,7 @@ class CContact extends w2p_Core_BaseObject
     public function canCreate()
     {
         $recordCount = $this->loadAll(null, "contact_email = '".$this->contact_email."'");
-        if (count($recordCount)) {
+        if (count($recordCount) && $this->contact_email != null) {
             $this->_error['canCreate'] = 'A contact with this email address already exists';
             return false;
         }


### PR DESCRIPTION
Allow a contact to be created with a blank email address. Instead of
using placeholder text for the email address that might get saved by
accident, we leave it blank. Then when checking that email address
does not exist, if it is blank we allow creation.
