### PR TITLE
Id1334

### DIFF
--- a/modules/projectdesigner/do_task_bulk_aed.php
+++ b/modules/projectdesigner/do_task_bulk_aed.php
@@ -21,11 +21,11 @@ $bulk_task_duration                  = w2PgetParam($_POST, 'bulk_task_duration',
 $bulk_task_durntype                  = w2PgetParam($_POST, 'bulk_task_durntype', '');
 $bulk_task_start_date                = w2PgetParam($_POST, 'add_task_bulk_start_date', '');
 $bulk_task_allow_other_user_tasklogs = w2PgetParam($_POST, 'bulk_task_allow_other_user_tasklogs', '');
-
+$add_task_bulk_time_keep             = w2PgetParam($_POST, 'add_task_bulk_time_keep', '0');
 $userTZ = $AppUI->getPref('TIMEZONE');
 
 if ($bulk_task_start_date) {
-	$start_date = new w2p_Utilities_Date($bulk_task_start_date,$userTZ);
+	$start_date_userTZ = $start_date = new w2p_Utilities_Date($bulk_task_start_date,$userTZ);
         $start_date->convertTZ('Europe/London');
 	$bulk_start_date = $start_date->format(FMT_DATETIME_MYSQL);
  //       $bulk_start_date=$CAppUI->convertToSystemTZ($bulk_start_date);
@@ -33,7 +33,7 @@ if ($bulk_task_start_date) {
 }
 $bulk_task_end_date = w2PgetParam($_POST, 'add_task_bulk_end_date', '');
 if ($bulk_task_end_date) {
-	$end_date = new w2p_Utilities_Date($bulk_task_end_date,$userTZ);
+	$end_date_userTZ = $end_date = new w2p_Utilities_Date($bulk_task_end_date,$userTZ);
         $end_date->convertTZ('Europe/London');
 	$bulk_end_date = $end_date->format(FMT_DATETIME_MYSQL);
 }
@@ -94,7 +94,17 @@ if (is_array($selected) && count($selected)) {
         //Action: Modify End Date
         if (isset($_POST['add_task_bulk_end_date']) && $bulk_task_end_date != '' && $bulk_end_date) {
             if ($upd_task->task_id) {
+              if ($add_task_bulk_time_keep) {
+                $end_date_old = new w2p_Utilities_Date($upd_task->task_end_date, $userTZ);
+                $end_date_userTZ->setHour($end_date_old->getHour());
+                $end_date_userTZ->setMinute($end_date_old->getMinute());
+                $end_date_userTZ->convertTZ('Europe/London');
+                $bulk_end_date = $end_date_userTZ->format(FMT_DATETIME_MYSQL);
                 $upd_task->task_end_date = $bulk_end_date;
+             
+              }
+                else {  $upd_task->task_end_date = $bulk_end_date;
+                };
                 $result = $upd_task->store();
                 if (!$result) {
                     break;
@@ -105,6 +115,14 @@ if (is_array($selected) && count($selected)) {
         //Action: Modify Start Date
         if (isset($_POST['add_task_bulk_start_date']) && $bulk_task_start_date != '' && $bulk_start_date) {
             if ($upd_task->task_id) {
+              if ($add_task_bulk_time_keep) {
+                $start_date_old = new w2p_Utilities_Date($upd_task->task_start_date, $userTZ);
+                $start_date_userTZ->setHour($start_date_old->getHour());
+                $start_date_userTZ->setMinute($start_date_old->getMinute());
+                $start_date_userTZ->convertTZ('Europe/London');
+                $bulk_start_date = $start_date_userTZ->format(FMT_DATETIME_MYSQL);
+             
+              };
                 $upd_task->task_start_date = $bulk_start_date;
                 $result = $upd_task->store();
                 if (!$result) {

--- a/modules/projectdesigner/vw_actions.php
+++ b/modules/projectdesigner/vw_actions.php
@@ -103,7 +103,12 @@ $spercent = arrayMerge(array('' => '('.$AppUI->_('Progress').')'), $percent);
                     <img src='<?php echo w2PfindImage('calendar.gif'); ?>' width='24' height='12' alt='<?php echo $AppUI->_('Calendar'); ?>' border='0' />
                 </a>
             </td>
-            <th width="15%" nowrap="nowrap"><?php echo $AppUI->_('Duration'); ?>&nbsp;</th>
+            <th width="15%" nowrap="nowrap"><?php echo $AppUI->_('Keep daytimes'); ?>&nbsp;</th>
+           <td width="160" nowrap="nowrap">
+                <input type='checkbox' id='add_task_bulk_time_keep' name='add_task_bulk_time_keep' value='1' checked />
+             </td>
+       </tr>
+        <tr>            <th width="15%" nowrap="nowrap"><?php echo $AppUI->_('Duration'); ?>&nbsp;</th>
             <td width="250" nowrap="nowrap">
                 <input type='text' class='text' style='width:120px;text-align:right;' id='bulk_task_duration' name='bulk_task_duration' value='' />&nbsp;
                 <?php echo arraySelect($sdurntype, 'bulk_task_durntype', 'style="width=120px" size="1" class="text"', '', true); ?>


### PR DESCRIPTION
needs parts of id1329

currently, projectdesigner chnages task dates and times with a single calendar control.

Sometimes, one just wants to adjust the date: e.g. when I edit the task at 7pm and don't want the start time to changed to that time. Also, this curently cannot be used to adjust multiple tasks: all will be set to the same time of day, while I might only want to shift all task from today to tomorrow, starting at the original time of day.

FIX:

add checkbox to indicate whether times also should be adjusted. If not, they are ignored and the original hours, minutes are inserted.
My default is dates only (in the checkbox )
