### PR TITLE
change paramter calls of htmlentities to allow invalid code to be replac...

### DIFF
--- a/includes/main_functions.php
+++ b/includes/main_functions.php
@@ -379,7 +379,7 @@ function w2p_textarea($content)
 
     if ($content != '') {
         $result = $content;
-        $result = htmlentities($result, ENT_QUOTES, 'UTF-8');
+        $result = htmlentities($result, ENT_QUOTES |ENT_SUBSTITUTE|ENT_IGNORE, 'UTF-8',false);
 
         /*
          * Thanks to Alison Gianotto for two regular expressions to make our


### PR DESCRIPTION
...ed instead of returning empty string

see http://support.web2project.net/forums/229360-developer-break-room/suggestions/4876907-bug-in-w2ptextarea

currently returns empty string on bad code, new version: replaces bad code
