### PR TITLE
add progress to task notification email

### DIFF
--- a/classes/w2p/Output/EmailManager.class.php
+++ b/classes/w2p/Output/EmailManager.class.php
@@ -178,6 +178,7 @@ class w2p_Output_EmailManager
 //TODO: Priority not working for some reason, will wait till later
         $body .= $this->_AppUI->_('Priority', UI_OUTPUT_RAW) . ":\t\t" . $task->task_priority . "\n";
 //Priority does work now
+        $body .= $this->_AppUI->_('Progress', UI_OUTPUT_RAW) . ":\t\t" . $task->task_percent_complete . " % \n";
         $tmp_tz = $this->_AppUI->getPref('TIMEZONE');
         $user_prefs = $this->_AppUI->loadPrefs($user['assignee_id'], true);
         $this->_AppUI->user_prefs['TIMEZONE'] = $user_prefs['TIMEZONE'];


### PR DESCRIPTION
add progress % to notification email.

If not send, nobody can see when a task is finished/closed

May at 100%, one should add an CLOSED after the % to make it clearly visible? That is not yet uploaded.

Klaus
