### PR TITLE
Importtasks date weekday

### DIFF
--- a/modules/tasks/tasks.class.php
+++ b/modules/tasks/tasks.class.php
@@ -557,7 +557,7 @@ class CTask extends w2p_Core_BaseObject
 //opto      using this code, a project will be copied identically if imported to the same start date as
 //opto      the original project  
   
-  '        $timeOffset = $oldproject_start_date->dateDiff($project_start_date) ;
+        $timeOffset = $oldproject_start_date->dateDiff($project_start_date) ;
 
         array_unshift($task_list, $first_task);
         foreach($task_list as $orig_task) {


### PR DESCRIPTION
importtasks:
1) if tasks are imported to a new project with same start date, project is reproduced identically to original project
2) remove shift to working day for consistency with addedit tasks and w2p 2.x
3) if project is shifted by 1 day (for example from start sunday  to start Monday), al ltasks are shifted by 1 day, as expected
