### PR TITLE
fileexists: if project is 0, search file in /files, not in files/0 folde...

### DIFF
--- a/classes/w2p/FileSystem/Local.class.php
+++ b/classes/w2p/FileSystem/Local.class.php
@@ -104,7 +104,8 @@ class w2p_FileSystem_Local implements w2p_FileSystem_Interface
 
     public function exists($project_id, $filename)
     {
-        $fname = W2P_BASE_DIR . '/files/' . $project_id . '/' . $filename;
+       if ($project_id>0) $fname = W2P_BASE_DIR . '/files/' . $project_id . '/' . $filename;
+	      else $fname = W2P_BASE_DIR . '/files/'  . $filename;
         return file_exists($fname);
     }
 }


### PR DESCRIPTION
not sure that solves the problem on upgrade, but it solves the original bug 1467:

files without project were searched in files/0/, but stored to files/

!!! This must be consistent with the storage location of older versions!!

Klaus
