### PR TITLE
fix bug 1615: taskreminders not always set

### DIFF
--- a/modules/tasks/tasks.class.php
+++ b/modules/tasks/tasks.class.php
@@ -700,6 +700,7 @@ class CTask extends w2p_Core_BaseObject
             $last_task_data['last_date'],
             $this->getTaskCount($this->task_project)
         );
+		$this->addReminder();
 
         parent::hook_postStore();
     }


### PR DESCRIPTION
on change of task reminder global setting in sysadmin, no taskreminder is set if a task is edited but dates not changed.
Most likely, task reminders are also not reset if changed by dependency tracking, because I only found this in do_task_aed.php.

put addReminder into hook_postStore to accomplish that. See mantis id 1615
